### PR TITLE
fix: Resolve mdast-util-to-hast vulnerability (CVE-2025-66400)

### DIFF
--- a/changelog/2025-12-28-fix-mdast-util-to-hast-vulnerability.md
+++ b/changelog/2025-12-28-fix-mdast-util-to-hast-vulnerability.md
@@ -1,0 +1,18 @@
+# Fix mdast-util-to-hast security vulnerability (CVE-2025-66400)
+
+## Summary
+
+Fixed a medium severity security vulnerability in the `mdast-util-to-hast` transitive dependency by adding a pnpm override to force version 13.2.1 or higher.
+
+## Details
+
+- **Vulnerability**: CVE-2025-66400 / GHSA-4fh9-h7wg-q85m
+- **Severity**: Medium
+- **Issue**: Unsanitized class attribute could allow multiple classnames to be added in markdown source using character references
+- **Fixed by**: Adding `pnpm.overrides` in package.json to require mdast-util-to-hast >= 13.2.1
+- **New version**: 13.2.1
+
+## References
+
+- https://github.com/boluoim/astroberry/security/dependabot/63
+- https://github.com/syntax-tree/mdast-util-to-hast/security/advisories/GHSA-4fh9-h7wg-q85m

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "pnpm": {
     "overrides": {
-      "form-data": ">=4.0.4"
+      "form-data": ">=4.0.4",
+      "mdast-util-to-hast": ">=13.2.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   form-data: '>=4.0.4'
+  mdast-util-to-hast: '>=13.2.1'
 
 importers:
 
@@ -1590,8 +1591,8 @@ packages:
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
-  mdast-util-to-hast@13.2.0:
-    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   mdast-util-to-markdown@2.1.2:
     resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
@@ -4052,7 +4053,7 @@ snapshots:
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       parse5: 7.3.0
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
@@ -4068,7 +4069,7 @@ snapshots:
       comma-separated-tokens: 2.0.3
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
@@ -4309,7 +4310,7 @@ snapshots:
       '@types/mdast': 4.0.4
       unist-util-is: 6.0.0
 
-  mdast-util-to-hast@13.2.0:
+  mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -4854,7 +4855,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 


### PR DESCRIPTION
## Summary

- Fixed medium severity vulnerability CVE-2025-66400 in `mdast-util-to-hast`
- Added pnpm override to force `mdast-util-to-hast >= 13.2.1`
- Upgraded from vulnerable version 13.2.0 to 13.2.1

## Details

The `mdast-util-to-hast` package had an unsanitized class attribute vulnerability that could allow multiple classnames to be added in markdown source using character references.

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Verified `mdast-util-to-hast` upgraded to 13.2.1

Closes https://github.com/boluoim/astroberry/security/dependabot/63

🤖 Generated with [Claude Code](https://claude.com/claude-code)