### PR TITLE
fix: Resolve remaining security vulnerabilities

### DIFF
--- a/changelog/2025-12-28-fix-remaining-security-vulnerabilities.md
+++ b/changelog/2025-12-28-fix-remaining-security-vulnerabilities.md
@@ -1,0 +1,24 @@
+# Fix remaining security vulnerabilities
+
+## Summary
+
+Fixed 3 remaining security vulnerabilities by adding pnpm overrides.
+
+## Details
+
+### 1. mdast-util-to-hast (CVE-2025-66400) - Medium
+- **Issue**: Unsanitized class attribute could allow multiple classnames via character references in markdown
+- **Fixed by**: Upgrade to >= 13.2.1
+- **Alert**: https://github.com/boluoim/astroberry/security/dependabot/63
+
+### 2. undici (Alert #20) - Medium
+- **Fixed by**: Upgrade to >= 6.21.1
+- **Alert**: https://github.com/boluoim/astroberry/security/dependabot/20
+
+### 3. undici (Alert #29) - Low
+- **Fixed by**: Upgrade to >= 6.21.2
+- **Alert**: https://github.com/boluoim/astroberry/security/dependabot/29
+
+## New versions
+- mdast-util-to-hast: 13.2.1
+- undici: 7.16.0

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "overrides": {
       "form-data": ">=4.0.4",
       "glob": ">=10.5.0",
-      "axios": ">=1.12.0"
+      "axios": ">=1.12.0",
+      "mdast-util-to-hast": ">=13.2.1",
+      "undici": ">=6.21.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   form-data: '>=4.0.4'
   glob: '>=10.5.0'
   axios: '>=1.12.0'
+  mdast-util-to-hast: '>=13.2.1'
+  undici: '>=6.21.2'
 
 importers:
 
@@ -1570,8 +1572,8 @@ packages:
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
-  mdast-util-to-hast@13.2.0:
-    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   mdast-util-to-markdown@2.1.2:
     resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
@@ -2212,9 +2214,9 @@ packages:
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
-  undici@6.21.0:
-    resolution: {integrity: sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==}
-    engines: {node: '>=18.17'}
+  undici@7.16.0:
+    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
+    engines: {node: '>=20.18.1'}
 
   unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
@@ -3527,7 +3529,7 @@ snapshots:
       parse5: 7.2.1
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 6.21.0
+      undici: 7.16.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -3970,7 +3972,7 @@ snapshots:
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       parse5: 7.3.0
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
@@ -3986,7 +3988,7 @@ snapshots:
       comma-separated-tokens: 2.0.3
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
@@ -4221,7 +4223,7 @@ snapshots:
       '@types/mdast': 4.0.4
       unist-util-is: 6.0.0
 
-  mdast-util-to-hast@13.2.0:
+  mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -4762,7 +4764,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 
@@ -5091,7 +5093,7 @@ snapshots:
 
   undici-types@7.8.0: {}
 
-  undici@6.21.0: {}
+  undici@7.16.0: {}
 
   unicode-properties@1.4.1:
     dependencies:


### PR DESCRIPTION
Add pnpm overrides for:
- mdast-util-to-hast >= 13.2.1 (CVE-2025-66400, medium)
- undici >= 6.21.2 (alerts #20 and #29, medium/low)

Closes https://github.com/boluoim/astroberry/security/dependabot/63 Closes https://github.com/boluoim/astroberry/security/dependabot/20 Closes https://github.com/boluoim/astroberry/security/dependabot/29

🤖 Generated with [Claude Code](https://claude.com/claude-code)