### PR TITLE
fix: Add explicit include paths to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "astro/tsconfigs/strict",
+  "include": [".astro/types.d.ts", "src/**/*"],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
Adds explicit include array to resolve "No inputs were found" warning in IDEs. The inherited paths from astro/tsconfigs/strict use ${configDir} variable which TypeScript doesn't resolve correctly when reading the config directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)