### PR TITLE
feat: Replace Twitter icon with X icon

### DIFF
--- a/changelog/2025-12-28-twitter-to-x-icon.md
+++ b/changelog/2025-12-28-twitter-to-x-icon.md
@@ -1,0 +1,9 @@
+# Replace Twitter Icon with X Icon
+
+Updated the social media icon from Twitter to X (formerly Twitter).
+
+## Changes
+
+- **src/config/index.ts**: Changed social link name from "Twitter" to "X" and icon from `mdi:twitter` to `simple-icons:x`
+- **src/components/SocialBar.astro**: Added padding adjustment for X icon to match visual size of other icons
+- **package.json**: Added `@iconify-json/simple-icons` dependency for the X icon

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@astrojs/check": "^0.9.6",
     "@astrojs/tailwind": "^6.0.2",
     "@fontsource-variable/space-grotesk": "^5.0.16",
+    "@iconify-json/simple-icons": "^1.2.63",
     "astro": "^5.16.6",
     "astro-icon": "^1.0.3",
     "sharp": "^0.33.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@fontsource-variable/space-grotesk':
         specifier: ^5.0.16
         version: 5.1.0
+      '@iconify-json/simple-icons':
+        specifier: ^1.2.63
+        version: 1.2.63
       astro:
         specifier: ^5.16.6
         version: 5.16.6(@types/node@24.0.13)(jiti@1.21.7)(rollup@4.44.2)(typescript@5.8.3)(yaml@2.8.2)
@@ -315,6 +318,9 @@ packages:
 
   '@iconify-json/mdi@1.2.1':
     resolution: {integrity: sha512-dSkQU78gsZV6Yxnq78+LuX7jzeFC/5NAmz7O3rh558GimGFcwMVY/OtqRowIzjqJBmMmWZft7wkFV4TrwRXjlg==}
+
+  '@iconify-json/simple-icons@1.2.63':
+    resolution: {integrity: sha512-xZl2UWCwE58VlqZ+pDPmaUhE2tq8MVSTJRr4/9nzzHlDdjJ0Ud1VxNXPrwTSgESKY29iCQw3S0r2nJTSNNngHw==}
 
   '@iconify/tools@4.0.7':
     resolution: {integrity: sha512-zOJxKIfZn96ZRGGvIWzDRLD9vb2CsxjcLuM+QIdvwWbv6SWhm49gECzUnd4d2P0sq9sfodT7yCNobWK8nvavxQ==}
@@ -2820,6 +2826,10 @@ snapshots:
   '@fontsource-variable/space-grotesk@5.1.0': {}
 
   '@iconify-json/mdi@1.2.1':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/simple-icons@1.2.63':
     dependencies:
       '@iconify/types': 2.0.0
 

--- a/src/components/SocialBar.astro
+++ b/src/components/SocialBar.astro
@@ -8,7 +8,7 @@ import { config } from "~config";
         <div class="flex gap-x-3">
             {
                 config.social.map((item) => (
-                    <a href={item.url} target="_blank" rel="noopener noreferrer" aria-label={item.name}>
+                    <a href={item.url} target="_blank" rel="noopener noreferrer" aria-label={item.name} class="social-icon">
                         <Icon name={item.icon} class="w-7 h-7 md:w-8 md:h-8 cursor-pointer hover:text-brand" />
                     </a>
                 ))
@@ -16,3 +16,9 @@ import { config } from "~config";
         </div>
     )
 }
+
+<style>
+    .social-icon :global(svg[data-icon="simple-icons:x"]) {
+        padding: 0.15rem;
+    }
+</style>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,8 +23,8 @@ export const config: Config = {
             url: 'https://github.com/boluoim/astroberry'
         },
         {
-            name: 'Twitter',
-            icon: 'mdi:twitter',
+            name: 'X',
+            icon: 'simple-icons:x',
             url: 'https://github.com/boluoim/astroberry'
         },
         {


### PR DESCRIPTION
## Summary

- Replace Twitter social icon with X (formerly Twitter) branding
- Add `@iconify-json/simple-icons` dependency for the X icon
- Adjust X icon padding to match visual size of other social icons

## Test plan

- [ ] Verify X icon displays correctly in the social bar
- [ ] Check icon size matches other social icons visually
- [ ] Test hover state works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)