### PR TITLE
feat: Switch to Geist font family

### DIFF
--- a/changelog/2025-12-28-geist-font.md
+++ b/changelog/2025-12-28-geist-font.md
@@ -1,0 +1,9 @@
+# Switch to Geist Font Family
+
+Replaced Space Grotesk with Geist Sans and Geist Mono fonts.
+
+## Changes
+
+- **src/layouts/Layout.astro**: Import Geist Sans and Geist Mono fonts (weights 400-700)
+- **tailwind.config.mjs**: Update font family configuration to use Geist Sans for sans-serif and Geist Mono for monospace
+- **package.json**: Replace `@fontsource-variable/space-grotesk` with `@fontsource/geist-sans` and `@fontsource/geist-mono`

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@astrojs/check": "^0.9.6",
     "@astrojs/tailwind": "^6.0.2",
-    "@fontsource-variable/space-grotesk": "^5.0.16",
+    "@fontsource/geist-mono": "^5.2.7",
+    "@fontsource/geist-sans": "^5.2.5",
     "@iconify-json/simple-icons": "^1.2.63",
     "astro": "^5.16.6",
     "astro-icon": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,12 @@ importers:
       '@astrojs/tailwind':
         specifier: ^6.0.2
         version: 6.0.2(astro@5.16.6(@types/node@24.0.13)(jiti@1.21.7)(rollup@4.44.2)(typescript@5.8.3)(yaml@2.8.2))(tailwindcss@3.4.17)
-      '@fontsource-variable/space-grotesk':
-        specifier: ^5.0.16
-        version: 5.1.0
+      '@fontsource/geist-mono':
+        specifier: ^5.2.7
+        version: 5.2.7
+      '@fontsource/geist-sans':
+        specifier: ^5.2.5
+        version: 5.2.5
       '@iconify-json/simple-icons':
         specifier: ^1.2.63
         version: 1.2.63
@@ -313,8 +316,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@fontsource-variable/space-grotesk@5.1.0':
-    resolution: {integrity: sha512-K2mwQYNyLook6EbtMB+Ix8srQsYZRigfxayoSGl1QsgVAk/J21s0FMZu0FWzTvONyQkYAR704rLfYSstVMi6jQ==}
+  '@fontsource/geist-mono@5.2.7':
+    resolution: {integrity: sha512-xVPVFISJg/K0VVd+aQN0Y7X/sw9hUcJPyDWFJ5GpyU3bHELhoRsJkPSRSHXW32mOi0xZCUQDOaPj1sqIFJ1FGg==}
+
+  '@fontsource/geist-sans@5.2.5':
+    resolution: {integrity: sha512-anllOHyJbElRs9fV15TeDRqAeb1IKm4bSknPl6ZMoyPTx1BBy7logudcUwpNjmQLkzn4Q0JGQLRCUKJYoyST6A==}
 
   '@iconify-json/mdi@1.2.1':
     resolution: {integrity: sha512-dSkQU78gsZV6Yxnq78+LuX7jzeFC/5NAmz7O3rh558GimGFcwMVY/OtqRowIzjqJBmMmWZft7wkFV4TrwRXjlg==}
@@ -2823,7 +2829,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.6':
     optional: true
 
-  '@fontsource-variable/space-grotesk@5.1.0': {}
+  '@fontsource/geist-mono@5.2.7': {}
+
+  '@fontsource/geist-sans@5.2.5': {}
 
   '@iconify-json/mdi@1.2.1':
     dependencies:

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,12 @@
 ---
-import '@fontsource-variable/space-grotesk'
+import '@fontsource/geist-sans/400.css'
+import '@fontsource/geist-sans/500.css'
+import '@fontsource/geist-sans/600.css'
+import '@fontsource/geist-sans/700.css'
+import '@fontsource/geist-mono/400.css'
+import '@fontsource/geist-mono/500.css'
+import '@fontsource/geist-mono/600.css'
+import '@fontsource/geist-mono/700.css'
 import { ClientRouter } from 'astro:transitions'
 import GoogleAnalytics from '~components/GoogleAnalytics.astro'
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -8,17 +8,8 @@ export default {
 	theme: {
 		extend: {
 			fontFamily: {
-				sans: ['"Space Grotesk Variable"', 'Inter', 'sans-serif', ...defaultTheme.fontFamily.sans],
-				code: [
-					'Menlo',
-					'Monaco',
-					'"Lucida Console"',
-					'"Liberation Mono"',
-					'"DejaVu Sans Mono"',
-					'"Bitstream Vera Sans Mono"',
-					'"Courier New"',
-					'monospace'
-				]
+				sans: ['"Geist Sans"', ...defaultTheme.fontFamily.sans],
+				mono: ['"Geist Mono"', ...defaultTheme.fontFamily.mono],
 			},
 		},
 		colors: {


### PR DESCRIPTION
## Summary

- Replace Space Grotesk with Geist Sans for body text
- Add Geist Mono for monospace/code text
- Include font weights 400, 500, 600, 700 for both fonts

## Test plan

- [ ] Verify Geist Sans renders correctly for body text
- [ ] Verify Geist Mono renders correctly for code blocks
- [ ] Check font weights display properly (regular, medium, semibold, bold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)