### PR TITLE
fix: Theme persistence and avatar navigation with View Transitions

### DIFF
--- a/changelog/2025-12-28-fix-theme-and-navigation.md
+++ b/changelog/2025-12-28-fix-theme-and-navigation.md
@@ -1,0 +1,8 @@
+# Fix Theme Persistence and Avatar Navigation
+
+Fixed two bugs related to View Transitions navigation.
+
+## Changes
+
+- **src/components/ThemeToggle.astro**: Add `astro:after-swap` event listener to persist theme after page navigation, and apply theme immediately on script load
+- **src/components/Avatar.astro**: Replace JavaScript click handler with semantic `<a>` tag for reliable home navigation

--- a/src/components/Avatar.astro
+++ b/src/components/Avatar.astro
@@ -8,17 +8,12 @@ interface Props {
 
 const props = Astro.props;
 ---
-<Image
-    id="avatar"
-    src={AvatarSrc}
-    alt="avatar"
-    class:list={[props.class]}
-    class="w-24 h-24 rounded-full cursor-pointer"
-    transition:name="avatar"
-/>
-
-<script>
-    import { navigate } from 'astro:transitions/client'
-
-    document.querySelector('#avatar')?.addEventListener('click', () => navigate('/'))
-</script>
+<a href="/">
+    <Image
+        src={AvatarSrc}
+        alt="avatar"
+        class:list={[props.class]}
+        class="w-24 h-24 rounded-full cursor-pointer"
+        transition:name="avatar"
+    />
+</a>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -112,7 +112,12 @@
 
     const theme = getPreference()
 
+    // Apply theme immediately on script load
+    reflectPreference()
+
+    // Also apply on page load and after View Transitions navigation
     window.onload = reflectPreference
+    document.addEventListener('astro:after-swap', reflectPreference)
 
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', ({matches:isDark}) => {
         theme.value = isDark ? 'dark' : 'light'


### PR DESCRIPTION
## Summary

- Fix theme resetting to default after navigating between pages
- Fix avatar click not navigating to home page

## Changes

- Add `astro:after-swap` event listener to reapply theme after View Transitions navigation
- Apply theme immediately on script load to prevent initial flash
- Replace JavaScript click handler with semantic `<a>` tag for avatar

## Test plan

- [ ] Switch to dark theme on homepage, click "Read Posts", verify theme persists
- [ ] On posts page, click avatar/logo, verify navigation to homepage
- [ ] Verify theme toggle animation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)