### PR TITLE
fix: Prevent dark mode flash on page load

### DIFF
--- a/changelog/2025-12-28-fix-dark-mode-flash.md
+++ b/changelog/2025-12-28-fix-dark-mode-flash.md
@@ -1,0 +1,7 @@
+# Fix Dark Mode Flash on Page Load
+
+Prevent flash of light theme when dark mode is active.
+
+## Changes
+
+- **src/layouts/Layout.astro**: Add inline script in `<head>` to set theme before page renders

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,6 +21,10 @@ const { title } = Astro.props
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
+		<script is:inline>
+			const theme = localStorage.getItem('theme-preference') || 'dark';
+			document.documentElement.setAttribute('data-theme', theme);
+		</script>
 		<meta name="description" content="Astroberry is a accessible, SEO-friendly and beautiful blog theme for Astro, built with TailwindCSS." />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />


### PR DESCRIPTION
## Summary

- Fix flash of light theme when loading page with dark mode preference

## Changes

- Add inline script in `<head>` to set `data-theme` before browser renders

## Test plan

- [ ] Refresh page with dark mode preference, verify no light flash
- [ ] Clear localStorage, refresh page, verify defaults to dark without flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)